### PR TITLE
serverQueryData 사용 시스템 및 쿼리 클라이언트 옵션값 에러 수정, API 응답 타입 수정, 디버깅

### DIFF
--- a/src/components/community/ArticleList/useArticleList.ts
+++ b/src/components/community/ArticleList/useArticleList.ts
@@ -6,7 +6,7 @@ import useCategory from "@lib/hooks/article/useActiveCategory";
 import useSearchText from "@lib/hooks/common/useSearchText";
 import { usePage } from "../../common/Pagination/usePagination";
 import { ARTICLE_LIST, ARTICLE_SEARCH } from "@lib/resources/articleResource";
-import { articleQueryKey } from "@lib/globalConst/queryKey";
+import localConsole from "@lib/utils/localConsole";
 
 export default function useArticleList(): {
   status: UseQueryResult["status"];
@@ -24,17 +24,21 @@ export default function useArticleList(): {
   const { categoryName: name, categoryId: id } = useCategory();
 
   const searchPayload = {
-    categoryId: id === 0 ? null : id,
-    page,
-    size: size.current,
-    searchText,
+    params: {
+      categoryId: id === 0 ? null : id,
+      page,
+      size: size.current,
+      searchText,
+    },
   };
 
   const defaultPayload = {
-    categoryId: id === 0 ? "" : id.toString(),
-    page,
-    size: size.current,
-    popular: false,
+    params: {
+      categoryId: id === 0 ? "" : id.toString(),
+      page,
+      size: size.current,
+      popular: false,
+    },
   };
 
   searchText

--- a/src/components/community/comment/CommentList/index.tsx
+++ b/src/components/community/comment/CommentList/index.tsx
@@ -13,6 +13,7 @@ import useDeleteComment from "@lib/hooks/comment/useDeleteComment";
 import { CommentListDiv } from "./styled";
 import CommunityModal from "../../CommunityModal";
 import { COMMENT_LIST } from "@lib/resources/commentResource";
+import localConsole from "@lib/utils/localConsole";
 
 export interface ItemProps {
   comment: CommentItem;
@@ -42,7 +43,7 @@ const CommentList = ({ Item }: Props) => {
       }),
     {
       getNextPageParam: (lastPage) => {
-        return lastPage.response.data.page + 1;
+        return lastPage.response.data.result.page + 1;
       },
       onError: (e) => {
         setHasNextPage(false);
@@ -88,8 +89,8 @@ const CommentList = ({ Item }: Props) => {
 
   return (
     <CommentListDiv>
-      {data?.pages.map(({ response: result }) =>
-        result.data.commentList.map((comment) => (
+      {data?.pages.map(({ response }) =>
+        response.data.result.commentList.map((comment) => (
           <Fragment key={comment.parent.id}>
             {!comment.parent.isDeleted && (
               <Item

--- a/src/components/hospital/HospitalDetail/index.tsx
+++ b/src/components/hospital/HospitalDetail/index.tsx
@@ -49,8 +49,8 @@ const HospitalDetail = ({ id }: { id: number }) => {
             <ChevronLeft />
           </button>
           <div>
-            <Link href={`/hospital/${data.response.data.id}`} passHref>
-              <h1>{data.response.data.name}</h1>
+            <Link href={`/hospital/${data.response.data.result.id}`} passHref>
+              <h1>{data.response.data.result.name}</h1>
             </Link>
             <Stats />
           </div>
@@ -63,12 +63,12 @@ const HospitalDetail = ({ id }: { id: number }) => {
         />
         <HospitalDetail.ButtonBox
           id={Number(router.query.id)}
-          name={data.response.data.name}
+          name={data.response.data.result.name}
         />
       </div>
       <LineDiv />
       <div className="wrapper">
-        <HospitalBasicInfo address={data.response.data.address} />
+        <HospitalBasicInfo address={data.response.data.result.address} />
         <PossibleAnimalList />
       </div>
       <LineDiv />

--- a/src/components/hospital/HospitalDetailReview/index.tsx
+++ b/src/components/hospital/HospitalDetailReview/index.tsx
@@ -45,12 +45,11 @@ const HospitalDetailReview = () => {
       <ReviewContainerHeader>
         {data && (
           <h3>
-            리뷰 <span>{data?.response.data.totalElements}</span>
+            리뷰 <span>{data.response.data.result.totalElements}</span>
           </h3>
         )}
       </ReviewContainerHeader>
-      {data?.response.data.reviews.map((item) => {
-        console.log(item);
+      {data?.response.data.result.reviews.map((item) => {
         return (
           <ReviewBox key={item.id}>
             <ReviewBoxHeader>

--- a/src/components/hospital/HospitalList/index.tsx
+++ b/src/components/hospital/HospitalList/index.tsx
@@ -17,6 +17,7 @@ import HospitalItem from "../HospitalItem";
 import { FilterButton, FilterDiv, Section } from "./styled";
 import hospitalOptions from "@lib/globalConst/hospitalOptions";
 import { HOSPITAL_LIST } from "@lib/resources/hospitalResource";
+import localConsole from "@lib/utils/localConsole";
 
 const HospitalList = () => {
   const ref = useRef<HTMLElement | null>(null);
@@ -51,6 +52,8 @@ const HospitalList = () => {
     }
   }, []);
 
+  localConsole?.log(data, "testdata");
+
   // page updated
   useDidMountEffect(() => {
     if (ref.current) {
@@ -71,7 +74,7 @@ const HospitalList = () => {
               .map((_, index) => (
                 <Skeleton width="100%" height="200px" key={index} />
               ))
-          : data.response.data.hospitals.map((hospital) => (
+          : data.response.data.result.hospitals.map((hospital) => (
               <HospitalItem
                 key={hospital.hospitals.id}
                 parent={ref}
@@ -83,7 +86,7 @@ const HospitalList = () => {
         <Pagination
           buttonNum={5}
           totalPages={Math.ceil(
-            data.response.data.totalCount / hospitalOptions.size
+            data.response.data.result.totalCount / hospitalOptions.size
           )}
         />
       )}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -34,7 +34,7 @@ const KakaoMap = () => {
   // }
 
   if (status === "success" && data && router.query.id) {
-    idMatchedData = data.response.data.hospitals.find(
+    idMatchedData = data.response.data.result.hospitals.find(
       (poiData) => poiData.hospitals.id.toString() === router.query.id
     );
   }
@@ -43,7 +43,7 @@ const KakaoMap = () => {
     <KakaoMap.Wrap
       poiData={
         status === "success" && data
-          ? idMatchedData || data.response.data.hospitals[0]
+          ? idMatchedData || data.response.data.result.hospitals[0]
           : undefined
       }
       isIdData={!!router.query.id}
@@ -57,7 +57,9 @@ const KakaoMap = () => {
         !router.query.id && (
           <KakaoMap.Bound poiDataList={data.data.hospitals} />
         )} */}
-      {data && <KakaoMap.List poiDataList={data?.response.data.hospitals} />}
+      {data && (
+        <KakaoMap.List poiDataList={data?.response.data.result.hospitals} />
+      )}
       <KakaoMap.RectSearch />
     </KakaoMap.Wrap>
   );

--- a/src/components/map/maptest/MapHandler.tsx
+++ b/src/components/map/maptest/MapHandler.tsx
@@ -56,7 +56,7 @@ const Init = ({
   const bounds = new kakao.maps.LatLngBounds();
 
   if (hospital.status === "success") {
-    const poiDataList = hospital.data.response.data.hospitals;
+    const poiDataList = hospital.data.response.data.result.hospitals;
 
     if (poiDataList.length > 1) {
       latLngList = poiDataList.map((poiData) => {
@@ -82,8 +82,8 @@ const Init = ({
 
     if (poiDataList.length <= 1) {
       options.center = new kakao.maps.LatLng(
-        hospital.data.response.data.hospitals[0].hospitals.latitude,
-        hospital.data.response.data.hospitals[0].hospitals.longitude
+        hospital.data.response.data.result.hospitals[0].hospitals.latitude,
+        hospital.data.response.data.result.hospitals[0].hospitals.longitude
       );
 
       setMarker({ map, kakaoLatLng: options.center });

--- a/src/containers/hospital/HospitalDetailContainer.tsx
+++ b/src/containers/hospital/HospitalDetailContainer.tsx
@@ -33,8 +33,8 @@ const HospitalDetailContainer = () => {
       />
       <Container>
         <section className="Section">
-          <h1 className="Title">{data.response.data.name}</h1>
-          <HospitalBasicInfo address={data.response.data.address} />
+          <h1 className="Title">{data.response.data.result.name}</h1>
+          <HospitalBasicInfo address={data.response.data.result.address} />
           <PossibleAnimalList />
           <ButtonBox divider id={Number(id)} />
         </section>

--- a/src/lib/API/petBookAPI/articleRequest.ts
+++ b/src/lib/API/petBookAPI/articleRequest.ts
@@ -1,3 +1,4 @@
+import localConsole from "@lib/utils/localConsole";
 import RequestCore from "./RequestCore";
 import {
   ArticleListResponse,
@@ -54,6 +55,9 @@ export default class ArticleAPI extends RequestCore {
       headerObj: payload?.headerObj,
     });
 
+    localConsole?.log(payload.pathParam, "pathParam");
+    localConsole?.log(requestURL, "requestURL");
+
     const result = await this.getResult<
       ArticleDetailResponse,
       ArticleDetailPayload
@@ -84,6 +88,8 @@ export default class ArticleAPI extends RequestCore {
       params: payload.params,
       headerObj: payload.headerObj,
     });
+
+    localConsole?.log(requestURL, "requestURL");
 
     const result = await this.getResult<
       ArticleListResponse,

--- a/src/lib/API/petBookAPI/articleRequest.ts
+++ b/src/lib/API/petBookAPI/articleRequest.ts
@@ -55,9 +55,6 @@ export default class ArticleAPI extends RequestCore {
       headerObj: payload?.headerObj,
     });
 
-    localConsole?.log(payload.pathParam, "pathParam");
-    localConsole?.log(requestURL, "requestURL");
-
     const result = await this.getResult<
       ArticleDetailResponse,
       ArticleDetailPayload
@@ -88,8 +85,6 @@ export default class ArticleAPI extends RequestCore {
       params: payload.params,
       headerObj: payload.headerObj,
     });
-
-    localConsole?.log(requestURL, "requestURL");
 
     const result = await this.getResult<
       ArticleListResponse,

--- a/src/lib/API/petBookAPI/commentRequest.ts
+++ b/src/lib/API/petBookAPI/commentRequest.ts
@@ -1,3 +1,4 @@
+import localConsole from "@lib/utils/localConsole";
 import RequestCore from "./RequestCore";
 import {
   CommentCreateRequest,
@@ -102,6 +103,7 @@ export default class CommentAPI extends RequestCore {
       headerObj: payload?.header,
       params: payload.params,
     });
+
     const result = this.getResult<CommentListResponse, CommentListPayload>({
       requestMethod: "GET",
       requestURL,

--- a/src/lib/API/petBookAPI/types/commentRequest.d.ts
+++ b/src/lib/API/petBookAPI/types/commentRequest.d.ts
@@ -35,13 +35,16 @@ export interface CommentListRequest {
   size: number;
 }
 
-export type CommentListResponse = {
-  page: number;
-  commentList: {
-    parent: CommentItem;
-    children: CommentItem[];
-  }[];
-};
+export interface CommentListResponse extends CommonRequestResult {
+  result: {
+    page: number;
+    totalElements: number;
+    commentList: {
+      parent: CommentItem;
+      children: CommentItem[];
+    }[];
+  };
+}
 
 export interface CommentErrorResponse {
   response: {

--- a/src/lib/API/petBookAPI/types/hospitalRequest.d.ts
+++ b/src/lib/API/petBookAPI/types/hospitalRequest.d.ts
@@ -26,7 +26,9 @@ export interface HospitalInfo {
 export interface HospitalDetailRequest {
   pathParam: string;
 }
-export type HospitalDetailResponse = HospitalInfo;
+export interface HospitalDetailResponse extends CommonRequestResult {
+  result: HospitalInfo;
+}
 
 // hospital_list
 
@@ -65,9 +67,7 @@ export interface HospitalListRequest {
   boundary?: string;
 }
 
-export interface HospitalListResponse {
-  code: string;
-  message: string | null;
+export interface HospitalListResponse extends CommonRequestResult {
   result: {
     totalCount: number;
     hospitals: HospitalFullInfo[];
@@ -140,9 +140,11 @@ export interface HospitalReviewListRequest {
   size: number;
 }
 
-export interface HospitalReviewListResponse {
-  reviews: HospitalReview[];
-  totalElements: number;
+export interface HospitalReviewListResponse extends CommonRequestResult {
+  result: {
+    reviews: HospitalReview[];
+    totalElements: number;
+  };
 }
 
 // TODO: 응답 타입 없음

--- a/src/lib/API/petBookAPI/types/hospitalRequest.d.ts
+++ b/src/lib/API/petBookAPI/types/hospitalRequest.d.ts
@@ -66,8 +66,12 @@ export interface HospitalListRequest {
 }
 
 export interface HospitalListResponse {
-  totalCount: number;
-  hospitals: HospitalFullInfo[];
+  code: string;
+  message: string | null;
+  result: {
+    totalCount: number;
+    hospitals: HospitalFullInfo[];
+  };
 }
 
 // export interface HospitalReviewRequest {

--- a/src/lib/API/petBookAPI/types/requestResult.d.ts
+++ b/src/lib/API/petBookAPI/types/requestResult.d.ts
@@ -1,0 +1,5 @@
+interface CommonRequestResult {
+  code: string;
+  message: string | null;
+  result: any;
+}

--- a/src/lib/globalConst/index.ts
+++ b/src/lib/globalConst/index.ts
@@ -6,11 +6,12 @@ export const cacheLifeTime = getMinToMs(5);
 export const queryClientOptions: QueryObserverOptions = {
   staleTime: cacheLifeTime,
   cacheTime: cacheLifeTime,
-  refetchInterval: cacheLifeTime,
-  // refetchOnMount: true,
-  // refetchOnReconnect: true,
-  refetchIntervalInBackground: true,
+  // refetchInterval: cacheLifeTime,
+  refetchOnMount: false,
+  refetchOnReconnect: false,
+  refetchIntervalInBackground: false,
   refetchOnWindowFocus: false,
+  refetchInterval: false,
   retry: 2,
 };
 

--- a/src/lib/hooks/common/useResource.ts
+++ b/src/lib/hooks/common/useResource.ts
@@ -47,6 +47,8 @@ export function useResource<P = ResourceParams, T = ResourceResult>({
     return resource.fetcher(resource.params as P);
   };
 
+  // localConsole?.log(resource, 'resource');
+
   return useQuery<GetResultReturn<T, P>>(
     resource.key as QueryKey,
     paramFetcher

--- a/src/lib/resources/articleResource.ts
+++ b/src/lib/resources/articleResource.ts
@@ -27,6 +27,13 @@ export const ARTICLE_LIST_PREVIEW = createResource({
   fetcher: articleRequest.article_list,
 });
 
+// export const ARTICLE_LIST_PREVIEW_LIST = new Array(ARTICLE_LIST_PREVIEW)
+//   .concat(ARTICLE_LIST_PREVIEW)
+//   .concat(ARTICLE_LIST_PREVIEW)
+//   .concat(ARTICLE_LIST_PREVIEW)
+//   .concat(ARTICLE_LIST_PREVIEW)
+//   .concat(ARTICLE_LIST_PREVIEW);
+
 export const ARTICLE_CREATE = createRequest({
   key: ["ARTICLE_CREATE"],
   requester: articleRequest.article_create,

--- a/src/lib/server/commonServerSideProps.ts
+++ b/src/lib/server/commonServerSideProps.ts
@@ -9,6 +9,7 @@ import getCookieList from "@lib/utils/getCookieList";
 import { checkDevice, checkUserAgent } from "@lib/utils/checkUserAgent";
 import { PageProps } from "@pages/_app";
 import { cookieKeyName } from "@lib/globalConst";
+import localConsole from "@lib/utils/localConsole";
 
 // 추후 특정 페이지에서 필요하지 않은 API 호출을 막는 용도로 사용할수 있음
 const userAPIBlackList = [""];
@@ -94,6 +95,28 @@ const commonServerSideProps = <R extends Array<Resource<any, any>>>(
         );
       }
 
+      const usedResource = queryClient
+        .getQueryCache()
+        .getAll()
+        .map((elem) => {
+          if (elem.queryKey[1]) {
+            const paramsObj = elem.queryKey[1] as { params: object };
+
+            return {
+              key: elem.queryKey,
+              name: elem.queryKey[0],
+              params: {
+                ...paramsObj.params,
+              },
+            };
+          }
+
+          return {
+            key: elem.queryKey,
+            name: elem.queryKey[0],
+          };
+        });
+
       return {
         props: {
           dehydratedState: dehydrate(queryClient),
@@ -102,7 +125,7 @@ const commonServerSideProps = <R extends Array<Resource<any, any>>>(
           cookieList,
           device,
           agentName,
-          requiredResources: JSON.parse(JSON.stringify(requiredResources)),
+          requiredResources: JSON.parse(JSON.stringify(usedResource)),
         },
       };
     } catch (err) {

--- a/src/lib/server/parse/ResourceParser/ArticleParser.ts
+++ b/src/lib/server/parse/ResourceParser/ArticleParser.ts
@@ -8,6 +8,7 @@ import {
 import ResourceParser from "./ResourceParser";
 import { categoryRequest } from "@lib/API/petBookAPI";
 import { itrMap } from "@lib/utils/iterableFunctions";
+import localConsole from "@lib/utils/localConsole";
 
 export default class ArticleParser extends ResourceParser {
   public listFetch = async () => {

--- a/src/lib/server/parse/ResourceParser/ArticleParser.ts
+++ b/src/lib/server/parse/ResourceParser/ArticleParser.ts
@@ -54,9 +54,11 @@ export default class ArticleParser extends ResourceParser {
 
   public detailFetch = async () => {
     const { query } = this.context;
+
     if (!query.articleId) return;
+
     const payload = {
-      pathParam: query.id as string,
+      pathParam: query.articleId as string,
     };
 
     return this.clientFetch<typeof ARTICLE_DETAIL["params"]>(payload);

--- a/src/lib/server/parse/ResourceParser/ResourceParser.ts
+++ b/src/lib/server/parse/ResourceParser/ResourceParser.ts
@@ -1,6 +1,7 @@
 import { GetServerSidePropsContext, NextPageContext } from "next";
 import type { QueryClient } from "@tanstack/react-query";
 import { Resource, ResourceParams } from "@lib/resources";
+import localConsole from "@lib/utils/localConsole";
 
 export default class ResourceParser {
   constructor(

--- a/src/lib/server/parse/getToken.ts
+++ b/src/lib/server/parse/getToken.ts
@@ -14,7 +14,7 @@ export default function getToken(
   const allCookies = cookies(ctx);
   const token = allCookies[cookieKeyName.userToken];
   if (token) {
-    sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${token}`;
+    // sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${token}`;
     if (options.decode) {
       const user = jwtDecode<DecodedUserInfo>(token);
       return {
@@ -22,8 +22,11 @@ export default function getToken(
         user,
       };
     }
-  } else if (typeof window === "undefined") {
-    sprPetBookClient.defaults.headers.common.Authorization = "";
   }
+
+  // else if (typeof window === "undefined") {
+  //   sprPetBookClient.defaults.headers.common.Authorization = "";
+  // }
+
   return { token: token || null, user: null };
 }

--- a/src/lib/server/parse/getToken.ts
+++ b/src/lib/server/parse/getToken.ts
@@ -14,7 +14,7 @@ export default function getToken(
   const allCookies = cookies(ctx);
   const token = allCookies[cookieKeyName.userToken];
   if (token) {
-    // sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${token}`;
+    sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${token}`;
     if (options.decode) {
       const user = jwtDecode<DecodedUserInfo>(token);
       return {

--- a/src/lib/utils/createQueryClient.ts
+++ b/src/lib/utils/createQueryClient.ts
@@ -6,8 +6,7 @@ export default function createQueryClient(
 ) {
   return new QueryClient({
     defaultOptions: {
-      ...queryClientOptions,
-      ...options,
+      queries: queryClientOptions,
     },
   });
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,17 +58,19 @@ const NextApp = ({ Component, pageProps, router }: DehydratedAppProps) => {
     sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${pageProps.token}`;
     const { userInfo } = tokenParser(pageProps.token);
     queryClient.setQueryData([cookieKeyName.userInfo], userInfo);
-  } else if (typeof window === "undefined") {
-    // 서버 사이드에서만 token을 가져올 수 있음. (http only cookie라서) 즉, token이 없는데 서버 사이드면 로그아웃 상태
-    sprPetBookClient.defaults.headers.common.Authorization = "";
-    queryClient.setQueryData([cookieKeyName.userInfo], "");
   }
+
+  // else if (typeof window === "undefined") {
+  //   // 서버 사이드에서만 token을 가져올 수 있음. (http only cookie라서) 즉, token이 없는데 서버 사이드면 로그아웃 상태
+  //   sprPetBookClient.defaults.headers.common.Authorization = "";
+  //   queryClient.setQueryData([cookieKeyName.userInfo], "");
+  // }
 
   if (
     process.env.NODE_ENV === "development" &&
     process.env.NEXT_PUBLIC_TESTER
   ) {
-    sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${process.env.NEXT_PUBLIC_TESTER}`;
+    // sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${process.env.NEXT_PUBLIC_TESTER}`;
   }
 
   // 웹 후크 연동 테스트

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,19 +58,17 @@ const NextApp = ({ Component, pageProps, router }: DehydratedAppProps) => {
     sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${pageProps.token}`;
     const { userInfo } = tokenParser(pageProps.token);
     queryClient.setQueryData([cookieKeyName.userInfo], userInfo);
+  } else if (typeof window === "undefined") {
+    // 서버 사이드에서만 token을 가져올 수 있음. (http only cookie라서) 즉, token이 없는데 서버 사이드면 로그아웃 상태
+    sprPetBookClient.defaults.headers.common.Authorization = "";
+    queryClient.setQueryData([cookieKeyName.userInfo], "");
   }
-
-  // else if (typeof window === "undefined") {
-  //   // 서버 사이드에서만 token을 가져올 수 있음. (http only cookie라서) 즉, token이 없는데 서버 사이드면 로그아웃 상태
-  //   sprPetBookClient.defaults.headers.common.Authorization = "";
-  //   queryClient.setQueryData([cookieKeyName.userInfo], "");
-  // }
 
   if (
     process.env.NODE_ENV === "development" &&
     process.env.NEXT_PUBLIC_TESTER
   ) {
-    // sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${process.env.NEXT_PUBLIC_TESTER}`;
+    sprPetBookClient.defaults.headers.common.Authorization = `Bearer ${process.env.NEXT_PUBLIC_TESTER}`;
   }
 
   // 웹 후크 연동 테스트

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -100,6 +100,8 @@ const NextApp = ({ Component, pageProps, router }: DehydratedAppProps) => {
   );
 };
 
+//
+
 // NextApp.getInitialProps = async (context: AppContext) => {
 //   const { Component, router, ctx } = context;
 //   const { token, user } = getToken(ctx, { decode: true });


### PR DESCRIPTION
1. 백엔드에 API 공통 응답 필드가 생겼습니다
이제 모든 응답은 result 필드안에 JSON 형식으로 지원해줄 예정일꺼니까 참고해주세용
응답 타입 인터페이스에 CommonRequestResult 를 extend 해서 쓰시면 됩니다
requestResult.d.ts 파일에 정의되어 있습니다

```
interface CommonRequestResult {
  code: string;
  message: string | null;
  result: any;
}

export interface CommentListResponse extends CommonRequestResult {
  result: {
    page: number;
    totalElements: number;
    commentList: {
      parent: CommentItem;
      children: CommentItem[];
    }[];
  };
}
```

2. server에 전달되었다가 다시 돌아오는 requiredResources 를 재조립 해서 내려줍니다.

```
@lib/server/commonServerSideProps.ts

...
    const usedResource = queryClient
        .getQueryCache()
        .getAll()
        .map((elem) => {
          if (elem.queryKey[1]) {
            const paramsObj = elem.queryKey[1] as { params: object };

            return {
              key: elem.queryKey,
              name: elem.queryKey[0],
              params: {
                ...paramsObj.params,
              },
            };
          }

          return {
            key: elem.queryKey,
            name: elem.queryKey[0],
          };
        });
        
       return {
        props: {
          dehydratedState: dehydrate(queryClient),
          token,
          user,
          cookieList,
          device,
          agentName,
          requiredResources: JSON.parse(JSON.stringify(usedResource)),
        },
      };
...

```

이렇게 key, name, params 만 추려서 NextApp 컴포넌트의 props 로 requiredResources를 내려줍니다
이유는 기존 커뮤니티 메인페이지의 리소스 호출 방식 때문인데요

```

public listPreviewFetch = async () => {
    const { response } = await categoryRequest.category_list();
    response.data.push({ id: 0, name: "전체" });

    const promises = Promise.all(
      itrMap(async (category) => {
        const { id } = category;
        const payload = {
          params: {
            categoryId: id === 0 ? "" : id.toString(),
            page: 0,
            size: 5,
            popular: false,
          },
        };

        return this.clientFetch<typeof ARTICLE_LIST_PREVIEW["params"]>(payload);
      }, response.data)
    );

    return promises;
  };

```

이런경우 Community Page 컴포넌트에서 commonServerSideProps 의 인자로 넘겨받은 리소스에는 ARTICLE_LIST_PREVIEW 라는 하나의 리소스 밖에 없는데, 6개의 리소스를 추가로 생성하고 queryClient 내부에 캐싱하게 됩니다
따라서 인자로받아온 requiredResources 를 그대로 내려주게되면, 기존 useServerQueryData 에서 해당 내용을 꺼내왔을때, 의도와 다르게
하나의 ARTICLE_LIST_PREVIEW 리소스만 담겨있고, 첫 렌더링시에는 server side data 만 이용하게 한다는 목적에 맞지가 않습니다.

따라서 실제로 캐싱한 모든 쿼리맵 내부의 리소스들을 꺼내고, key, name, params 만 조합하여 useServerQueryData 로 보내주도록 하였고,
commonServerSideProps 의 인자로 여러 리소스를 내려주던, parserSelector 내부에서 리소스를 여러개 생성하던 모두 동일하게 사용할수 있게 개발이 가능해졌어요.

다만, 이 방식이 옳은가에 대해서는 한번더 생각해 볼 필요가 있는것 같아요. 불필요한 연산도 늘어나고, 리소스의 흐름이 직관적이지 못하다는 단점이 있습니다. 물론 비슷한 상황에 리소스를 20~30개씩 생성하는 로직이라면 이런 방식을 사용하는게 맞는거 같긴한데, 모두 하나의 리소스를 참조하면서도 key 가 여러개인 리소스가 만약 클라이언트 조작으로 parameter 가 바뀌어 refetching 하게 되면 의도한대로 동작하지 않을것 같아요.
단한번만 렌더링 하면 되는 상황에서만 가능한 로직인것 같네요
