### PR TITLE
[feat] ci/cd 파이프라인 개선

### DIFF
--- a/.github/workflows/petBook-StoryBook-CD.yml
+++ b/.github/workflows/petBook-StoryBook-CD.yml
@@ -11,9 +11,6 @@ on:
       status:
         required: true
         type: string
-    secrets:
-      VERCEL_DEPLOY_TOKEN:
-        required: true
 
 jobs:
   deploy-production:

--- a/.github/workflows/petBook-Web-Client-CD.yml
+++ b/.github/workflows/petBook-Web-Client-CD.yml
@@ -3,14 +3,9 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
-  workflow_call:
-    inputs:
-      status:
-        required: true
-        type: string
-    secrets:
-      VERCEL_DEPLOY_TOKEN:
-        required: true
+  push:
+    branches:
+      - dev
 # https://github.com/vercel/examples/tree/main/ci-cd/github-actions
 # 이거 참조해주세욤
 
@@ -37,5 +32,3 @@ jobs:
     uses: ./.github/workflows/petBook-StoryBook-CD.yml
     with:
       status: 'Success'
-    secrets:
-      VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}

--- a/.github/workflows/petBook-Web-Client-CI.yml
+++ b/.github/workflows/petBook-Web-Client-CI.yml
@@ -3,10 +3,7 @@ name: petBook Web Client CI
 # 구독할 이벤트
 on:
   workflow_dispatch:
-  push:
-    branches: [dev]
   pull_request:
-    branches: [dev]
 
 # jobs 단위로 개별 서버(정확히는 Docker 컨테이너 단위라고 한다.)에서 작업이 수행된다.
 # 각 작업은 병렬로 실행 된다고 하는데, needs: build와 같이 표시해서 기다릴 수도 있다.
@@ -32,11 +29,24 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: build
+  vercel-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Install Yarn
+        run: npm install --global yarn
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_DEPLOY_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_DEPLOY_TOKEN }}
   ci-notify:
     name: Discord Notification
     runs-on: ubuntu-latest
     needs:
       - problem-check
+      - vercel-check
     if: ${{ always() }}
     steps:
       - name: ci-notify
@@ -54,13 +64,3 @@ jobs:
           color-success: '#008d62'
           color-failure: '#9b111e'
           color-cancelled: '#ffd400'
-  call-cd-workflow:
-    needs:
-      - problem-check
-      - ci-notify
-    if: ${{ success() && github.event_name == 'push' }}
-    uses: ./.github/workflows/petBook-Web-Client-CD.yml
-    with:
-      status: 'Success'
-    secrets:
-      VERCEL_DEPLOY_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN }}


### PR DESCRIPTION
CI에 아시다시피 다음 작업을 진행합니다. 해당 작업은 무겁기 떄문에 여러번 실행하면 오래걸리게 됩니다.
- yarn install
- yarn lint
- yarn build
그리고, Web Client와 StoryBook를 배포할 때도 build도 하기 때문에 CI -> 배포 -> 배포 순서로하면 build만 3번하는 것입니다. 

## 1. CI작업을 PR올릴 때만 돌아가게 변경

### AS-IS
- PR을 올렸을 때
    - CI 
- dev에 머지했을 때 
    - CI -> Web Client 배포 -> StoryBook 배포 

### TO-BE
- PR을 올렸을 때 
    - CI
- dev에 머지했을 때
    - Web Client 배포 -> Story Book 배포 

## 2. VERCEL_DEPLOY_TOKEN을 input에서 받던것을 제거
- 어차피 secrets 에서 가져오는 값인데 불필요하게 workflow input으로 받고 있었고, 이것을 제거했습니다.

## 3. CI에서 vercel build도 하도록 변경
- 오늘 @steven-yn 님께 전달듣기로는 yarn build는 성공했지만, vercel build는 실패하는 사례가 존재한다고 들었습니다.
- 제가 추측하기로는 yarn build에서 명시한 버전에서는 문제 없지만, vercel 안에서 돌아가는 npm, node 등의 버전에서 문제 생기는것으로 추측됩니다.
- 그래서 CI에서 vercel build까지 추가하여 PR에서 해당 버전이 문제가 없는지 체크할 수 있도록 변경하였습니다.


--- 
Web Client 배포와 StoryBook 배포가 순차적으로 진행되는 것이 비효율적으로 보입니다.
지금은 이 순서를 지킬 수 있도록 반영하고, CI에서 vercel build했을 때 배포하는것에도 문제없다라는것이 추후에 증명되면 WebClient와 StoryBook 동시에 배포할 수 있도록 변경하면 좋을 것 같습니다.