### PR TITLE
hotfix: disable buttonRef props control in button story

### DIFF
--- a/src/components/community/CategoryNav/index.tsx
+++ b/src/components/community/CategoryNav/index.tsx
@@ -11,6 +11,7 @@ const CategoryNav = () => {
   const { categories, status } = useCategories({ all: true });
   const { categoryName } = useActiveCategory();
   const router = useRouter();
+  const isList = router.asPath.includes("list");
   const onClick = (category: CategoryItem) => () => {
     navigator({
       url: getHrefWithCategory(category),
@@ -20,16 +21,17 @@ const CategoryNav = () => {
     });
   };
   return (
-    <CategoryNavDiv list={router.asPath.includes("list")}>
+    <CategoryNavDiv list={isList}>
       {status === "success"
         ? categories.map((category) => (
             <Button
-              variant="tertiary"
+              variant={
+                categoryName === category.name ? "tertiary active" : "tertiary"
+              }
               key={category.id}
               onClick={onClick(category)}
-              active={categoryName === category.name ? true : false}
-              width={router.asPath.includes("list") ? "110px" : "132px"}
-              height={router.asPath.includes("list") ? "44px" : "52px"}
+              width={isList ? "110px" : "132px"}
+              height={isList ? "44px" : "52px"}
             >
               {category.name}
             </Button>

--- a/src/components/community/CategoryNav/index.tsx
+++ b/src/components/community/CategoryNav/index.tsx
@@ -26,7 +26,7 @@ const CategoryNav = () => {
         ? categories.map((category) => (
             <Button
               variant={
-                categoryName === category.name ? "tertiary active" : "tertiary"
+                categoryName === category.name ? "tertiary-active" : "tertiary"
               }
               key={category.id}
               onClick={onClick(category)}

--- a/src/stories/common/Button/Button.stories.tsx
+++ b/src/stories/common/Button/Button.stories.tsx
@@ -33,7 +33,7 @@ export const Tertiary: Story = {
 };
 export const TertiaryActive: Story = {
   args: {
-    variant: "tertiary active",
+    variant: "tertiary-active",
     children: "질문과 답변",
   },
 };

--- a/src/stories/common/Button/Button.stories.tsx
+++ b/src/stories/common/Button/Button.stories.tsx
@@ -6,6 +6,11 @@ const meta: Meta<typeof Button> = {
   title: "common/Button",
   component: Button,
   tags: ["autodocs"],
+  argTypes: {
+    buttonRef: {
+      control: false,
+    },
+  },
 };
 type Story = StoryObj<typeof Button>;
 export const Primary: Story = {
@@ -28,9 +33,8 @@ export const Tertiary: Story = {
 };
 export const TertiaryActive: Story = {
   args: {
-    variant: "tertiary",
+    variant: "tertiary active",
     children: "질문과 답변",
-    active: true,
   },
 };
 

--- a/src/stories/common/Button/index.tsx
+++ b/src/stories/common/Button/index.tsx
@@ -2,27 +2,19 @@ import React, { type PropsWithChildren } from "react";
 import { StyledButton } from "./style";
 import type { TypographyVariant } from "../Typography";
 
-interface CommonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "tertiary" | "tertiary-active" | "small";
+  width?: string;
+  height?: string;
   hidden?: boolean;
-  buttonRef?: React.RefObject<HTMLButtonElement>;
+  color?: string;
   hoverColor?: string;
+  bgColor?: string;
   hoverBgColor?: string;
   typography?: TypographyVariant;
-  bgColor?: string;
-  color?: string;
+  buttonRef?: React.RefObject<HTMLButtonElement>;
 }
-
-export type ButtonProps = CommonProps &
-  (
-    | {
-        variant?: "primary" | "secondary" | "tertiary" | "tertiary-active";
-        width?: string;
-        height?: string;
-      }
-    | {
-        variant: "small";
-      }
-  );
 
 const Button = ({
   children,
@@ -39,8 +31,6 @@ const Button = ({
 Button.defaultProps = {
   type: "button" as const,
   disabled: false,
-  width: "100%",
-  height: "3.25rem",
   hidden: false,
 };
 

--- a/src/stories/common/Button/index.tsx
+++ b/src/stories/common/Button/index.tsx
@@ -14,7 +14,7 @@ interface CommonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export type ButtonProps = CommonProps &
   (
     | {
-        variant?: "primary" | "secondary" | "tertiary" | "tertiary active";
+        variant?: "primary" | "secondary" | "tertiary" | "tertiary-active";
         width?: string;
         height?: string;
         bgColor?: string;

--- a/src/stories/common/Button/index.tsx
+++ b/src/stories/common/Button/index.tsx
@@ -8,6 +8,7 @@ interface CommonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   hoverColor?: string;
   hoverBgColor?: string;
   typography?: TypographyVariant;
+  bgColor?: string;
   color?: string;
 }
 
@@ -17,11 +18,9 @@ export type ButtonProps = CommonProps &
         variant?: "primary" | "secondary" | "tertiary" | "tertiary-active";
         width?: string;
         height?: string;
-        bgColor?: string;
       }
     | {
         variant: "small";
-        bgColor: string;
       }
   );
 

--- a/src/stories/common/Button/index.tsx
+++ b/src/stories/common/Button/index.tsx
@@ -3,27 +3,25 @@ import { StyledButton } from "./style";
 import type { TypographyVariant } from "../Typography";
 
 interface CommonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  active?: boolean;
   hidden?: boolean;
   buttonRef?: React.RefObject<HTMLButtonElement>;
   hoverColor?: string;
   hoverBgColor?: string;
   typography?: TypographyVariant;
+  color?: string;
 }
 
 export type ButtonProps = CommonProps &
   (
     | {
-        variant?: "primary" | "secondary" | "tertiary";
+        variant?: "primary" | "secondary" | "tertiary" | "tertiary active";
         width?: string;
         height?: string;
         bgColor?: string;
-        color?: string;
       }
     | {
         variant: "small";
         bgColor: string;
-        color: string;
       }
   );
 
@@ -41,7 +39,6 @@ const Button = ({
 
 Button.defaultProps = {
   type: "button" as const,
-  active: false,
   disabled: false,
   width: "100%",
   height: "3.25rem",

--- a/src/stories/common/Button/style.tsx
+++ b/src/stories/common/Button/style.tsx
@@ -63,7 +63,7 @@ export const StyledButton = styled.button<ButtonProps>`
     props?.variant !== "small" &&
     css`
       width: ${props.width};
-      height: ${props.height}; ;
+      height: ${props.height};
     `};
   ${(props) =>
     props?.variant === "primary"
@@ -71,9 +71,9 @@ export const StyledButton = styled.button<ButtonProps>`
       : props?.variant === "secondary"
       ? SecondaryStyle
       : props?.variant === "tertiary"
-      ? props.active
-        ? TertiaryActiveStyle
-        : TertiaryStyle
+      ? TertiaryStyle
+      : props.variant === "tertiary active"
+      ? TertiaryActiveStyle
       : props?.variant === "small"
       ? SmallButtonStyle
       : null};

--- a/src/stories/common/Button/style.tsx
+++ b/src/stories/common/Button/style.tsx
@@ -45,8 +45,6 @@ const TertiaryActiveStyle = css`
 `;
 
 const SmallButtonStyle = css`
-  width: fit-content;
-  height: fit-content;
   padding: 0.25rem 1rem;
   border-radius: 40px;
   ${TextBodySmallMedium};
@@ -60,12 +58,6 @@ export const StyledButton = styled.button<ButtonProps>`
   transition: all 0.3s ease;
 
   ${(props) =>
-    props?.variant !== "small" &&
-    css`
-      width: ${props.width};
-      height: ${props.height};
-    `};
-  ${(props) =>
     props?.variant === "primary"
       ? PrimaryStyle
       : props?.variant === "secondary"
@@ -77,6 +69,13 @@ export const StyledButton = styled.button<ButtonProps>`
       : props?.variant === "small"
       ? SmallButtonStyle
       : null};
+  ${(props) =>
+    css`
+      width: ${props.width ||
+      (props?.variant === "small" ? "fit-content" : "100%")};
+      height: ${props.height ||
+      (props?.variant === "small" ? "fit-content" : "100%")};
+    `};
   ${(props) =>
     props.bgColor &&
     css`

--- a/src/stories/common/Button/style.tsx
+++ b/src/stories/common/Button/style.tsx
@@ -72,7 +72,7 @@ export const StyledButton = styled.button<ButtonProps>`
       ? SecondaryStyle
       : props?.variant === "tertiary"
       ? TertiaryStyle
-      : props.variant === "tertiary active"
+      : props.variant === "tertiary-active"
       ? TertiaryActiveStyle
       : props?.variant === "small"
       ? SmallButtonStyle

--- a/src/stories/common/Button/style.tsx
+++ b/src/stories/common/Button/style.tsx
@@ -74,7 +74,7 @@ export const StyledButton = styled.button<ButtonProps>`
       width: ${props.width ||
       (props?.variant === "small" ? "fit-content" : "100%")};
       height: ${props.height ||
-      (props?.variant === "small" ? "fit-content" : "100%")};
+      (props?.variant === "small" ? "fit-content" : "3.25rem")};
     `};
   ${(props) =>
     props.bgColor &&


### PR DESCRIPTION
## 문제점

1. storybook에서 `buttonRef` props를 설정하면 에러 발생
2. storybook 내에서 `active` props의 역할을 파악하기 힘듦
   - `variant` props값이 `tertiary` 일때만 `active` props를 사용함.

## 해결

1. `buttonRef`는 UI에 영향이 없는 props라서 storybook에서 control할 수 없도록 설정 변경
   -  참고: `WriteImgAttach` 컴포넌트에서 `buttonRef` props를 사용함.
2. `active` props를 삭제하고, `variant` 타입에 `tertiary-active` 추가함.

+) props가 `Union Type` 이었는데 storybook에서 유니온 타입인지 파악하기 어려워서 유니온 타입을 삭제하고 `Interface`로 props 타입 수정
