### PR TITLE
feat: 디스코드 노티 (pr open, reopen 일때만)

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -2,8 +2,7 @@ name: Discord Notification
 
 on:
   pull_request:
-    - opened
-    - reopened
+    types: [ opened, reopened ]
 
 jobs:
   notify:

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -17,7 +17,7 @@ jobs:
           username: 'petBot'
           avatar-url: 'https://cdn.discordapp.com/app-icons/1044621624864940163/87fe18353f90a7a4c275be945afc14e5.png?size=512'
           title: '${{ github.workflow }} : ${{ github.event_name }}'
-          description: "PR이 오픈되었습니다."
+          description: "PR이 (재)오픈되었습니다.\n코드 리뷰 부탁드립니다."
           include-details: 'false'
           color-success: '#008d62'
           color-failure: '#9b111e'

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,0 +1,25 @@
+name: Discord Notification
+
+on:
+  pull_request:
+    - opened
+    - reopened
+
+jobs:
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: discord-notification
+        uses: nobrayner/discord-webhook@v1
+        with:
+          github-token: ${{ secrets.github_token }}
+          discord-webhook: ${{ secrets.UPDATE_WEBHOOK }}
+          username: 'petBot'
+          avatar-url: 'https://cdn.discordapp.com/app-icons/1044621624864940163/87fe18353f90a7a4c275be945afc14e5.png?size=512'
+          title: '${{ github.workflow }} : ${{ github.event_name }}'
+          description: "PR이 오픈되었습니다."
+          include-details: 'false'
+          color-success: '#008d62'
+          color-failure: '#9b111e'
+          color-cancelled: '#ffd400'

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -2,7 +2,7 @@ name: Discord Notification
 
 on:
   pull_request:
-    types: [ opened, reopened ]
+    types: [opened, reopened]
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary
- 디스코드 알림을 대부분 꺼놔서 알림이 자주 안울려서 좋은 것 같은데요.
- PR올라왔을 때 바로바로 다같이 알면 좋지 않을까 해서, PR이 생길 때도 디코 알림이 울리도록 추가해보았습니다. 
- 이 PR이 반영되면 아래일 때만 알림이 옵니다.
    - PR이 생길 때(재오픈도)
    - 상용 배포 진행 완료(서버 2개다)  

## Description of changes

<!-- 변경 내용을 설명해주세요 -->

## Additional context
- 코드보다는 Summary 만 검토해주셔도 충분할 것 같습니다.

## Checklist
- [x] [Code Convention](https://www.notion.so/af63c0fdf7874983aa5940ca4f529bae?v=591a6e18cd96470d8f5cfebe852f9507#729915eb34164cf9b3a57d2e4ee8fb7b)을 지켰는지 확인해주세요
