### PR TITLE
update: preview discord 알림 설정을 변견한다

### DIFF
--- a/.github/workflows/preview-stroy-book.yml
+++ b/.github/workflows/preview-stroy-book.yml
@@ -68,7 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - deploy-production
-    if: ${{ always() }}
+      - check-comment
+    if: ${{ always() }} && needs.check-comment.outputs.triggered == 'true'
     steps:
       - name: cd-notify
         uses: nobrayner/discord-webhook@v1

--- a/.github/workflows/preview-web-client.yml
+++ b/.github/workflows/preview-web-client.yml
@@ -65,7 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - deploy-production
-    if: ${{ always() }}
+      - check-comment
+    if: ${{ always() }} && needs.check-comment.outputs.triggered == 'true'
     steps:
       - name: cd-notify
         uses: nobrayner/discord-webhook@v1


### PR DESCRIPTION
## Summary

- preview discord알림이 comment 등록될 때 마다 discord로 알림이 가고 있습니다.
- comment 중에서 /story-book, /web-client 입력했을 때만 디스코드로 알림이 오도록 변경합니다.

## Description of changes

<!-- 변경 내용을 설명해주세요 -->

## Additional context

<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 설명해주세요  -->

## Checklist
- [x] [Code Convention](https://www.notion.so/af63c0fdf7874983aa5940ca4f529bae?v=591a6e18cd96470d8f5cfebe852f9507#729915eb34164cf9b3a57d2e4ee8fb7b)을 지켰는지 확인해주세요
